### PR TITLE
fix digest error on window resize

### DIFF
--- a/angular-scrollable-table.js
+++ b/angular-scrollable-table.js
@@ -171,7 +171,9 @@
           });
 
           angular.element(window).on('resize', function(){
-            $scope.$apply();
+            $timeout(function(){
+              $scope.$apply();
+            });
           });
           $scope.$watch(function(){
             return $element.find('.scrollArea').width();


### PR DESCRIPTION
when it used with another angular module like angular-fullscreen the digest error will happen.