### PR TITLE
Now removes the resize listener on window when going out of scope

### DIFF
--- a/angular-scrollable-table.js
+++ b/angular-scrollable-table.js
@@ -173,10 +173,14 @@
             renderChains($element.find('.scrollArea').width());
           });
 
-          angular.element(window).on('resize', function(){
+          var onResizeCallback = function(){
             $timeout(function(){
               $scope.$apply();
             });
+          };
+          angular.element(window).on('resize', onResizeCallback);
+          $scope.$on('$destroy', function() {
+            angular.element(window).off('resize', onResizeCallback);
           });
           $scope.$watch(function(){
             return $element.find('.scrollArea').width();


### PR DESCRIPTION
Fixed the issue described here: [https://github.com/alalonde/angular-scrollable-table/issues/51](https://github.com/alalonde/angular-scrollable-table/issues/51)