### PR TITLE
Handle undefined values when comparing during sort

### DIFF
--- a/angular-scrollable-table.js
+++ b/angular-scrollable-table.js
@@ -77,6 +77,8 @@
             var y = $parse(exprParts[2])(scope);
 
             if (x === y) return 0;
+            if (x == null) && (y != null) return 1;
+            if (x != null) && (y == null) return -1;            
             return x > y ? 1 : -1;
           }
 

--- a/angular-scrollable-table.js
+++ b/angular-scrollable-table.js
@@ -77,8 +77,8 @@
             var y = $parse(exprParts[2])(scope);
 
             if (x === y) return 0;
-            if (x == null) && (y != null) return 1;
-            if (x != null) && (y == null) return -1;            
+            if ((x == null) && (y != null)) return 1;
+            if ((x != null) && (y == null)) return -1;            
             return x > y ? 1 : -1;
           }
 


### PR DESCRIPTION
Handle undefined values in the default comparison function thus providing the same guarantee as Array.prototype.sort() makes, namely that "All undefined elements are sorted to the end of the array."
Fixes issue #65